### PR TITLE
Fix GCExchange

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.translations.globallink</groupId>
 	<artifactId>gcc-restclient</artifactId>
-	<version>2.2.1</version>
+	<version>2.3.0-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 	<name>globallink-connect-restclient</name>
 	<description>GlobalLink Connect Cloud java is a library to connect your system to GlobalLink Connect Cloud REST API.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.scm.id>git-scm-server</project.scm.id>
+        <powermock.version>1.7.1</powermock.version>
 	</properties>
 	<scm>
 		<connection>scm:git:https://github.com/translations-com/globallink-connect-cloud-api-java.git</connection>
@@ -28,17 +29,33 @@
 	</scm>
 	
 	<dependencies>
+  
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 			<version>2.9.7</version>
 		</dependency>
+    
+        <!-- Test dependencies -->
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.12</version>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+          <groupId>org.powermock</groupId>
+          <artifactId>powermock-module-junit4</artifactId>
+          <version>${powermock.version}</version>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.powermock</groupId>
+          <artifactId>powermock-api-mockito</artifactId>
+          <version>${powermock.version}</version>
+          <scope>test</scope>
+        </dependency>
+        
 	</dependencies>
 	
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -44,16 +44,16 @@
 			<scope>test</scope>
 		</dependency>
         <dependency>
-          <groupId>org.powermock</groupId>
-          <artifactId>powermock-module-junit4</artifactId>
-          <version>${powermock.version}</version>
-          <scope>test</scope>
+			<groupId>org.powermock</groupId>
+          	<artifactId>powermock-module-junit4</artifactId>
+          	<version>${powermock.version}</version>
+          	<scope>test</scope>
         </dependency>
         <dependency>
-          <groupId>org.powermock</groupId>
-          <artifactId>powermock-api-mockito</artifactId>
-          <version>${powermock.version}</version>
-          <scope>test</scope>
+          	<groupId>org.powermock</groupId>
+          	<artifactId>powermock-api-mockito</artifactId>
+          	<version>${powermock.version}</version>
+          	<scope>test</scope>
         </dependency>
         
 	</dependencies>

--- a/src/main/java/org/gs4tr/gcc/restclient/GCConfig.java
+++ b/src/main/java/org/gs4tr/gcc/restclient/GCConfig.java
@@ -1,5 +1,8 @@
 package org.gs4tr.gcc.restclient;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class GCConfig {
 
     private String apiUrl;
@@ -7,6 +10,7 @@ public class GCConfig {
     private String password;
     private String connectorKey;
     private String userAgent;
+    private Map<String, String> customHeaders = new HashMap<>();
 
     private String bearerToken;
 
@@ -15,67 +19,138 @@ public class GCConfig {
     }
 
     public GCConfig(String apiUrl, String userName, String password) {
-	this.apiUrl = apiUrl;
-	this.userName = userName;
-	this.password = password;
+        this.apiUrl = apiUrl;
+        this.userName = userName;
+        this.password = password;
     }
 
     public GCConfig(String apiUrl, String userName, String password, String connectorKey) {
-	this(apiUrl, userName, password);
-	this.connectorKey = connectorKey;
+        this(apiUrl, userName, password);
+        this.connectorKey = connectorKey;
     }
 
     public GCConfig(String apiUrl, String userName, String password, String connectorKey, String userAgent) {
-	this(apiUrl, userName, password, connectorKey);
-	this.userAgent = userAgent;
+        this(apiUrl, userName, password, connectorKey);
+        this.userAgent = userAgent;
+    }
+
+    public GCConfig(String apiUrl, String userName, String password, String connectorKey, String userAgent,
+            Map<String, String> customHeaders) {
+        this(apiUrl, userName, password, connectorKey, userAgent);
+        this.customHeaders.putAll(customHeaders);
     }
 
     public String getApiUrl() {
-	return apiUrl;
+        return apiUrl;
     }
 
     public void setApiUrl(String apiUrl) {
-	this.apiUrl = apiUrl;
+        this.apiUrl = apiUrl;
     }
 
     public String getUserName() {
-	return userName;
+        return userName;
     }
 
     public void setUserName(String userName) {
-	this.userName = userName;
+        this.userName = userName;
     }
 
     public String getPassword() {
-	return password;
+        return password;
     }
 
     public void setPassword(String password) {
-	this.password = password;
+        this.password = password;
     }
 
     public String getUserAgent() {
-	return userAgent;
+        return userAgent;
     }
 
     public void setUserAgent(String userAgent) {
-	this.userAgent = userAgent;
+        this.userAgent = userAgent;
     }
 
     public String getBearerToken() {
-	return bearerToken;
+        return bearerToken;
     }
 
     public void setBearerToken(String bearerToken) {
-	this.bearerToken = bearerToken;
+        this.bearerToken = bearerToken;
     }
 
     public String getConnectorKey() {
-	return connectorKey;
+        return connectorKey;
     }
 
     public void setConnectorKey(String connectorKey) {
-	this.connectorKey = connectorKey;
+        this.connectorKey = connectorKey;
+    }
+
+    public Map<String, String> getCustomHeaders() {
+        return customHeaders;
+    }
+
+    public void addCustomHeader(String name, String value) {
+        customHeaders.put(name, name);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        
+        private String apiUrl;
+        private String userName;
+        private String password;
+        private String connectorKey;
+        private String userAgent;
+        private Map<String, String> customHeaders = new HashMap<>();
+        
+        private Builder() {
+        }
+
+        public Builder apiUrl(String apiUrl) {
+            this.apiUrl = apiUrl;
+            return this;
+        }
+
+        public Builder userName(String userName) {
+            this.userName = userName;
+            return this;
+        }
+
+        public Builder password(String password) {
+            this.password = password;
+            return this;
+        }
+
+        public Builder connectorKey(String connectorKey) {
+            this.connectorKey = connectorKey;
+            return this;
+        }
+
+        public Builder userAgent(String userAgent) {
+            this.userAgent = userAgent;
+            return this;
+        }
+
+        public Builder customHeader(String name, String value) {
+            customHeaders.put(name, value);
+            return this;
+        }
+
+        public Builder customHeaders(Map<String, String> headers) {
+            customHeaders.putAll(headers);
+            return this;
+        }
+
+        public GCConfig build() {
+            return new GCConfig(apiUrl, userName, password, connectorKey, userAgent, customHeaders);
+        }
+
     }
 
 }

--- a/src/main/java/org/gs4tr/gcc/restclient/GCConfig.java
+++ b/src/main/java/org/gs4tr/gcc/restclient/GCConfig.java
@@ -101,14 +101,14 @@ public class GCConfig {
     }
 
     public static class Builder {
-        
+
         private String apiUrl;
         private String userName;
         private String password;
         private String connectorKey;
         private String userAgent;
         private Map<String, String> customHeaders = new HashMap<>();
-        
+
         private Builder() {
         }
 

--- a/src/main/java/org/gs4tr/gcc/restclient/GCExchange.java
+++ b/src/main/java/org/gs4tr/gcc/restclient/GCExchange.java
@@ -81,7 +81,6 @@ import org.gs4tr.gcc.restclient.request.UploadFileContextRequest;
 import org.gs4tr.gcc.restclient.request.UploadFileRequest;
 import org.gs4tr.gcc.restclient.util.APIUtils;
 import org.gs4tr.gcc.restclient.util.StringUtils;
-import org.w3c.dom.DOMException;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -119,13 +118,6 @@ public class GCExchange {
 
         if (StringUtils.IsNullOrWhiteSpace(this.config.getBearerToken())) {
             login();
-            try {
-                getConnectors();
-            } catch (DOMException e) {
-                throw new IllegalArgumentException("Error parsing response", e);
-            } catch (Exception e) {
-                throw new IllegalArgumentException("Incorrect client_secret_key", e);
-            }
         }
 
     }

--- a/src/main/java/org/gs4tr/gcc/restclient/GCExchange.java
+++ b/src/main/java/org/gs4tr/gcc/restclient/GCExchange.java
@@ -92,48 +92,49 @@ public class GCExchange {
     private GCConfig config = null;
 
     public GCExchange(GCConfig config) {
-	this.init(config);
+        this.init(config);
     }
     
     public GCConfig getConfig() {
-	return this.config;
+        return this.config;
     }
 
     private void init(GCConfig conf) {
-	if (StringUtils.IsNullOrWhiteSpace(conf.getApiUrl())) {
-	    throw new IllegalArgumentException("APIUrl is required");
-	}
-	if(StringUtils.IsNullOrWhiteSpace(conf.getBearerToken())) {
-	    if (StringUtils.IsNullOrWhiteSpace(conf.getUserName())) {
-		throw new IllegalArgumentException("Username is required");
-	    }
-	    if (StringUtils.IsNullOrWhiteSpace(conf.getPassword())) {
-		throw new IllegalArgumentException("Password is required");
-	    }
-	}
+        if (StringUtils.IsNullOrWhiteSpace(conf.getApiUrl())) {
+            throw new IllegalArgumentException("APIUrl is required");
+        }
+        if (StringUtils.IsNullOrWhiteSpace(conf.getBearerToken())) {
+            if (StringUtils.IsNullOrWhiteSpace(conf.getUserName())) {
+                throw new IllegalArgumentException("Username is required");
+            }
+            if (StringUtils.IsNullOrWhiteSpace(conf.getPassword())) {
+                throw new IllegalArgumentException("Password is required");
+            }
+        }
 
-	this.config = conf;
-	if (!this.config.getApiUrl().endsWith("/")) {
-	    this.config.setApiUrl(this.config.getApiUrl() + "/");
-	}
+        this.config = conf;
+        if (!this.config.getApiUrl().endsWith("/")) {
+            this.config.setApiUrl(this.config.getApiUrl() + "/");
+        }
 
-	if(StringUtils.IsNullOrWhiteSpace(this.config.getBearerToken())) {
-	    login();
-	    try {
-		    getConnectors();
-		} catch (DOMException e) {
-		    throw new IllegalArgumentException("Error parsing response", e);
-		} catch (Exception e) {
-		    throw new IllegalArgumentException("Incorrect client_secret_key", e);
-		}
-	}
+        if (StringUtils.IsNullOrWhiteSpace(this.config.getBearerToken())) {
+            login();
+            try {
+                getConnectors();
+            } catch (DOMException e) {
+                throw new IllegalArgumentException("Error parsing response", e);
+            } catch (Exception e) {
+                throw new IllegalArgumentException("Incorrect client_secret_key", e);
+            }
+        }
 
     }
 
     private void login() {
-	SessionStartResponse response = (SessionStartResponse)APIUtils.doRequest(new SessionStart(config));
-	String token = response.getResponseData().getUserSessionKey();
-	config.setBearerToken(token);
+        SessionStartResponse response = (SessionStartResponse) APIUtils.doRequest(new SessionStart(config));
+        String token = response.getResponseData()
+                .getUserSessionKey();
+        config.setBearerToken(token);
     }
     
     /**
@@ -142,12 +143,12 @@ public class GCExchange {
      * @return Is success
      */
     public Boolean logout() {
-	APIUtils.doRequest(new SessionTerminate(config));
-	return true;
+        APIUtils.doRequest(new SessionTerminate(config));
+        return true;
     }
     
     public void setConnectorKey(String connectorKey) {
-	config.setConnectorKey(connectorKey);
+        config.setConnectorKey(connectorKey);
     }
     
     /**
@@ -156,7 +157,7 @@ public class GCExchange {
      * @return Session token
      */
     public String getSessionToken() {
-	return config.getBearerToken();
+        return config.getBearerToken();
     }
     
     /**
@@ -165,8 +166,8 @@ public class GCExchange {
      * @return List of {@link Connector}
      */
     public List<Connector> getConnectors() {
-	ConnectorsResponse response = (ConnectorsResponse)APIUtils.doRequest(new Connectors(config));
-	return response.getResponseData();
+        ConnectorsResponse response = (ConnectorsResponse) APIUtils.doRequest(new Connectors(config));
+        return response.getResponseData();
     }
     
     /**
@@ -175,8 +176,8 @@ public class GCExchange {
      * @return Connector config as {@link ConnectorsConfigResponseData} including supported locales and file types
      */
     public ConnectorsConfigResponseData getConnectorsConfig() {
-	ConnectorsConfigResponse response = (ConnectorsConfigResponse)APIUtils.doRequest(new ConnectorsConfig(config));
-	return response.getResponseData();
+        ConnectorsConfigResponse response = (ConnectorsConfigResponse) APIUtils.doRequest(new ConnectorsConfig(config));
+        return response.getResponseData();
     }
     
     /**
@@ -185,8 +186,8 @@ public class GCExchange {
      * @return Paged list of {@link GCFile}
      */
     public ContentResponseData getContentList() {
-	ContentResponse response = (ContentResponse)APIUtils.doRequest(new Content(this.config));
-	return response.getResponseData();
+        ContentResponse response = (ContentResponse) APIUtils.doRequest(new Content(this.config));
+        return response.getResponseData();
     }
     
     /**
@@ -196,8 +197,8 @@ public class GCExchange {
      * @return Paged list of {@link GCFile}
      */
     public ContentResponseData getContentList(PageableRequest request) {
-	ContentResponse response = (ContentResponse)APIUtils.doRequest(new Content(this.config, request));
-	return response.getResponseData();
+        ContentResponse response = (ContentResponse) APIUtils.doRequest(new Content(this.config, request));
+        return response.getResponseData();
     }
     
     /**
@@ -207,8 +208,10 @@ public class GCExchange {
      * @return Id of uploaded content
      */
     public String uploadContent(UploadFileRequest request){
-	ContentDataResponse response = (ContentDataResponse)APIUtils.doRequestWithParameters(new ContentData(config, request));
-	return response.getResponseData().getContentId();
+        ContentDataResponse response = (ContentDataResponse) APIUtils
+                .doRequestWithParameters(new ContentData(config, request));
+        return response.getResponseData()
+                .getContentId();
     }
     
     /**
@@ -218,8 +221,10 @@ public class GCExchange {
      * @return Id of uploaded reference
      */
     public String uploadContentReference(UploadContentReferenceRequest request){
-	ContentReferenceResponse response = (ContentReferenceResponse)APIUtils.doRequestWithParameters(new ContentReference(config, request));
-	return response.getResponseData().getReferenceId();
+        ContentReferenceResponse response = (ContentReferenceResponse) APIUtils
+                .doRequestWithParameters(new ContentReference(config, request));
+        return response.getResponseData()
+                .getReferenceId();
     }
     
     /**
@@ -228,8 +233,9 @@ public class GCExchange {
      * @return List of XSLT profiles
      */
     public List<String> getContextConfigs(){
-	ContextConfigResponse response = (ContextConfigResponse)APIUtils.doRequest(new ContextConfig(config));
-	return response.getResponseData().getXsltConfigs();
+        ContextConfigResponse response = (ContextConfigResponse) APIUtils.doRequest(new ContextConfig(config));
+        return response.getResponseData()
+                .getXsltConfigs();
     }
     
     /**
@@ -239,8 +245,9 @@ public class GCExchange {
      * @return Static preview url of uploaded context
      */
     public String uploadContext(UploadFileContextRequest request){
-	ContextResponse response = (ContextResponse)APIUtils.doRequestWithParameters(new Context(config, request));
-	return response.getResponseData().getStaticUrl();
+        ContextResponse response = (ContextResponse) APIUtils.doRequestWithParameters(new Context(config, request));
+        return response.getResponseData()
+                .getStaticUrl();
     }
     
     /**
@@ -250,8 +257,8 @@ public class GCExchange {
      * @return Paged list of {@link GCJob}
      */
     public JobsResponseData getJobsList(JobListRequest request) {
-	JobsResponse response = (JobsResponse)APIUtils.doRequest(new Jobs(config, request));
-	return response.getResponseData();
+        JobsResponse response = (JobsResponse) APIUtils.doRequest(new Jobs(config, request));
+        return response.getResponseData();
     }
     
     /**
@@ -261,8 +268,8 @@ public class GCExchange {
      * @return {@link State}
      */
     public State getJobState(Long jobId) {
-	StatusResponse response = (StatusResponse)APIUtils.doRequest(new JobStatus(config, new JobRequest(jobId)));
-	return response.getResponseData();
+        StatusResponse response = (StatusResponse) APIUtils.doRequest(new JobStatus(config, new JobRequest(jobId)));
+        return response.getResponseData();
     }
     
     /**
@@ -272,8 +279,8 @@ public class GCExchange {
      * @return Paged list of {@link GCTask}
      */
     public TasksResponseData getJobTasks(JobRequest jobRequest) {
-	TasksResponse response = (TasksResponse)APIUtils.doRequest(new JobTasks(config, jobRequest));
-	return response.getResponseData();
+        TasksResponse response = (TasksResponse) APIUtils.doRequest(new JobTasks(config, jobRequest));
+        return response.getResponseData();
     }
     
     /**
@@ -283,8 +290,9 @@ public class GCExchange {
      * @return List of {@link WordCountSummary}
      */
     public List<WordCountSummary> getJobWordCount(Long jobId) {
-	JobWordCountResponse response = (JobWordCountResponse)APIUtils.doRequest(new JobWordCount(config, new JobRequest(jobId)));
-	return response.getResponseData();
+        JobWordCountResponse response = (JobWordCountResponse) APIUtils
+                .doRequest(new JobWordCount(config, new JobRequest(jobId)));
+        return response.getResponseData();
     }
     
     /**
@@ -293,8 +301,8 @@ public class GCExchange {
      * @return Paged list of {@link GCSubmission}
      */
     public SubmissionsResponseData getSubmissionsList() {
-	SubmissionsResponse response = (SubmissionsResponse)APIUtils.doRequest(new Submissions(config, null));
-	return response.getResponseData();
+        SubmissionsResponse response = (SubmissionsResponse) APIUtils.doRequest(new Submissions(config, null));
+        return response.getResponseData();
     }
     
     /**
@@ -304,8 +312,8 @@ public class GCExchange {
      * @return Paged list of {@link GCSubmission}
      */
     public SubmissionsResponseData getSubmissionsList(SubmissionsListRequest request) {
-	SubmissionsResponse response = (SubmissionsResponse)APIUtils.doRequest(new Submissions(config, request));
-	return response.getResponseData();
+        SubmissionsResponse response = (SubmissionsResponse) APIUtils.doRequest(new Submissions(config, request));
+        return response.getResponseData();
     }
     
     /**
@@ -315,8 +323,10 @@ public class GCExchange {
      * @return Id of created submission
      */
     public Long createSubmission(SubmissionCreateRequest request) {
-	SubmissionCreateResponse response = (SubmissionCreateResponse)APIUtils.doRequest(new SubmissionCreate(config, request));
-	return response.getResponseData().getSubmissionId();
+        SubmissionCreateResponse response = (SubmissionCreateResponse) APIUtils
+                .doRequest(new SubmissionCreate(config, request));
+        return response.getResponseData()
+                .getSubmissionId();
     }
     
     /**
@@ -326,8 +336,9 @@ public class GCExchange {
      * @return Paged list of {@link GCJob}
      */
     public JobsResponseData getSubmissionJobs(Long submissionId) {
-	JobsResponse response = (JobsResponse)APIUtils.doRequest(new SubmissionJobs(config, new SubmissionRequest(submissionId)));
-	return response.getResponseData();
+        JobsResponse response = (JobsResponse) APIUtils
+                .doRequest(new SubmissionJobs(config, new SubmissionRequest(submissionId)));
+        return response.getResponseData();
     }
     
     /**
@@ -337,8 +348,9 @@ public class GCExchange {
      * @return Submission {@link State}
      */
     public State getSubmissionState(Long submissionId) {
-	StatusResponse response = (StatusResponse)APIUtils.doRequest(new SubmissionStatus(config, new SubmissionRequest(submissionId)));
-	return response.getResponseData();
+        StatusResponse response = (StatusResponse) APIUtils
+                .doRequest(new SubmissionStatus(config, new SubmissionRequest(submissionId)));
+        return response.getResponseData();
     }
     
     /**
@@ -348,8 +360,9 @@ public class GCExchange {
      * @return MessageResponse {@link MessageResponse} response with status and message
      */
     public MessageResponse cancelSubmission(Long submissionId) {
-	MessageResponse response = (MessageResponse)APIUtils.doRequest(new SubmissionCancel(config, new SubmissionRequest(submissionId)));
-	return response;
+        MessageResponse response = (MessageResponse) APIUtils
+                .doRequest(new SubmissionCancel(config, new SubmissionRequest(submissionId)));
+        return response;
     }
     
     /**
@@ -359,8 +372,8 @@ public class GCExchange {
      * @return MessageResponse {@link MessageResponse} response with status and message
      */
     public MessageResponse cancelJob(Long jobId) {
-	MessageResponse response = (MessageResponse)APIUtils.doRequest(new JobCancel(config, new JobRequest(jobId)));
-	return response;
+        MessageResponse response = (MessageResponse) APIUtils.doRequest(new JobCancel(config, new JobRequest(jobId)));
+        return response;
     }
     
     /**
@@ -370,8 +383,9 @@ public class GCExchange {
      * @return {@link SubmissionSubmitResponseData} object which contains submission id and jobs
      */
     public SubmissionSubmitResponseData submitSubmission(SubmissionSubmitRequest request) {
-	SubmissionSubmitResponse response = (SubmissionSubmitResponse)APIUtils.doRequest(new SubmissionSubmit(config, request));
-	return response.getResponseData();
+        SubmissionSubmitResponse response = (SubmissionSubmitResponse) APIUtils
+                .doRequest(new SubmissionSubmit(config, request));
+        return response.getResponseData();
     }
     
     /**
@@ -381,8 +395,8 @@ public class GCExchange {
      * @return Paged list of {@link GCTask}
      */
     public TasksResponseData getSubmissionTasks(SubmissionRequest request) {
-	TasksResponse response = (TasksResponse)APIUtils.doRequest(new SubmissionTasks(config, request));
-	return response.getResponseData();
+        TasksResponse response = (TasksResponse) APIUtils.doRequest(new SubmissionTasks(config, request));
+        return response.getResponseData();
     }
     
     /**
@@ -392,8 +406,10 @@ public class GCExchange {
      * @return List of submission {@link SubmissionWordCountData}
      */
     public List<SubmissionWordCountData> getSubmissionWordCount(Long submissionId) {
-	SubmissionWordCountResponse response = (SubmissionWordCountResponse)APIUtils.doRequest(new SubmissionWordCount(config, new SubmissionRequest(submissionId)));
-	return response.getResponseData().getWordcountData();
+        SubmissionWordCountResponse response = (SubmissionWordCountResponse) APIUtils
+                .doRequest(new SubmissionWordCount(config, new SubmissionRequest(submissionId)));
+        return response.getResponseData()
+                .getWordcountData();
     }
     
     /**
@@ -403,8 +419,8 @@ public class GCExchange {
      * @return Paged list of {@link GCTask}
      */
     public TasksResponseData getTasksList(TaskListRequest request) {
-	TasksResponse response = (TasksResponse)APIUtils.doRequest(new Tasks(config, request));
-	return response.getResponseData();
+        TasksResponse response = (TasksResponse) APIUtils.doRequest(new Tasks(config, request));
+        return response.getResponseData();
     }
     
     /**
@@ -414,8 +430,8 @@ public class GCExchange {
      * @return MessageResponse {@link MessageResponse} response with status and message
      */
     public MessageResponse setTaskError(TaskErrorRequest request) {
-	MessageResponse response = (MessageResponse)APIUtils.doRequest(new TasksError(config, request));
-	return response;
+        MessageResponse response = (MessageResponse) APIUtils.doRequest(new TasksError(config, request));
+        return response;
     }
     
     /**
@@ -425,8 +441,10 @@ public class GCExchange {
      * @return Is success
      */
     public Boolean confirmTask(Long taskId) {
-	TasksConfirmResponse response = (TasksConfirmResponse)APIUtils.doRequest(new TasksConfirm(config, new TaskRequest(taskId)));
-	return response.getResponseData().getIsSuccess();
+        TasksConfirmResponse response = (TasksConfirmResponse) APIUtils
+                .doRequest(new TasksConfirm(config, new TaskRequest(taskId)));
+        return response.getResponseData()
+                .getIsSuccess();
     }
     
     /**
@@ -436,8 +454,10 @@ public class GCExchange {
      * @return  List of confirm cancellation failures. If list is empty, then result is success for all specified task ids
      */
     public List<TaskConfirmCancellationFailure> confirmTaskCancellation(List<Long> taskIds) {
-	TasksConfirmCancellationResponse response = (TasksConfirmCancellationResponse)APIUtils.doRequest(new TasksConfirmCancellation(config, new TasksRequest(taskIds)));
-	return response.getResponseData().getTaskConfirmCancellationFailures();
+        TasksConfirmCancellationResponse response = (TasksConfirmCancellationResponse) APIUtils
+                .doRequest(new TasksConfirmCancellation(config, new TasksRequest(taskIds)));
+        return response.getResponseData()
+                .getTaskConfirmCancellationFailures();
     }
     
     /**
@@ -447,7 +467,7 @@ public class GCExchange {
      * @return Completed task data as InputStream
      */
     public InputStream downloadTask(Long taskId) {
-	return APIUtils.doDownload(new TasksDownload(config, new TaskRequest(taskId)));
+        return APIUtils.doDownload(new TasksDownload(config, new TaskRequest(taskId)));
     }
     
     /**
@@ -458,8 +478,8 @@ public class GCExchange {
      * @throws JsonProcessingException Json generation exception
      */
     public String createJson(Object object) throws JsonProcessingException {
-	ObjectMapper mapper = new ObjectMapper();
-	return mapper.writeValueAsString(object);
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.writeValueAsString(object);
     }
     
     /**
@@ -474,8 +494,8 @@ public class GCExchange {
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public Object parseJson(String json, Class outputClass) throws JsonParseException, JsonMappingException, IOException {
-	ObjectMapper mapper = new ObjectMapper();
-	return mapper.readValue(json, outputClass);
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.readValue(json, outputClass);
     }
 
 }

--- a/src/main/java/org/gs4tr/gcc/restclient/util/APIUtils.java
+++ b/src/main/java/org/gs4tr/gcc/restclient/util/APIUtils.java
@@ -104,8 +104,8 @@ public class APIUtils {
 
 	    return responseObj;
 	} catch (IOException e) {
-	    throw new IllegalStateException("Error sending request: " + e.getMessage());
-	}
+            throw new IllegalStateException("Error sending request: " + e.getMessage());
+        }
     }
 
     public static InputStream doDownload(GCOperation operation) {

--- a/src/main/java/org/gs4tr/gcc/restclient/util/HttpUtils.java
+++ b/src/main/java/org/gs4tr/gcc/restclient/util/HttpUtils.java
@@ -1,0 +1,20 @@
+package org.gs4tr.gcc.restclient.util;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Map;
+
+public class HttpUtils {
+
+    public static HttpURLConnection openConnection(URL url) throws IOException {
+        return (HttpURLConnection) url.openConnection();
+    }
+
+    public static void addHeaders(HttpURLConnection connection, Map<String, String> headers) {
+        for (Map.Entry<String, String> header : headers.entrySet()) {
+            connection.setRequestProperty(header.getKey(), header.getValue());
+        }
+    }
+
+}

--- a/src/main/java/org/gs4tr/gcc/restclient/util/MultipartUtility.java
+++ b/src/main/java/org/gs4tr/gcc/restclient/util/MultipartUtility.java
@@ -1,5 +1,8 @@
 package org.gs4tr.gcc.restclient.util;
 
+import static org.gs4tr.gcc.restclient.util.HttpUtils.addHeaders;
+import static org.gs4tr.gcc.restclient.util.HttpUtils.openConnection;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
@@ -25,17 +28,16 @@ public class MultipartUtility {
     private OutputStream outputStream;
     private PrintWriter writer;
  
-    public MultipartUtility(String requestURL, GCConfig config)
+    public MultipartUtility(URL requestURL, GCConfig config)
             throws IOException {
          
         boundary = "===" + System.currentTimeMillis() + "===";
-         
-        URL url = new URL(requestURL);
-        httpConn = (HttpsURLConnection) url.openConnection();
+        httpConn = (HttpsURLConnection) openConnection(requestURL);
         httpConn.setRequestMethod("POST");
         httpConn.setRequestProperty("connector_key", config.getConnectorKey());
         httpConn.setRequestProperty("Authorization", "Bearer " + config.getBearerToken());
         httpConn.setRequestProperty("Content-Type", "application/json;charset=utf-8");
+        addHeaders(httpConn, config.getCustomHeaders());
         httpConn.setUseCaches(false);
         httpConn.setDoOutput(true); // indicates POST method
         httpConn.setDoInput(true);
@@ -84,7 +86,7 @@ public class MultipartUtility {
         writer.append(name + ": " + value).append(LINE_FEED);
         writer.flush();
     }
-     
+
     public HttpsURLConnection finish() throws IOException {
  
         writer.append(LINE_FEED).flush();

--- a/src/test/java/org/gs4tr/gcc/restclient/util/APIUtilsTest.java
+++ b/src/test/java/org/gs4tr/gcc/restclient/util/APIUtilsTest.java
@@ -1,0 +1,127 @@
+package org.gs4tr.gcc.restclient.util;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyMapOf;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.net.ssl.HttpsURLConnection;
+
+import org.gs4tr.gcc.restclient.GCConfig;
+import org.gs4tr.gcc.restclient.dto.GCResponse;
+import org.gs4tr.gcc.restclient.model.GCFile;
+import org.gs4tr.gcc.restclient.operation.Content;
+import org.gs4tr.gcc.restclient.operation.Content.ContentResponse;
+import org.gs4tr.gcc.restclient.operation.Content.ContentResponseData;
+import org.gs4tr.gcc.restclient.operation.GCOperation;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@PrepareForTest({ HttpUtils.class })
+@RunWith(PowerMockRunner.class)
+public class APIUtilsTest {
+
+    private static final GCConfig TEST_CONFIG = getTestConfig();
+    private static final int OK = 200;
+
+    private HttpURLConnection mockConnection;
+
+    @Before
+    public void setUpMocks() throws IOException {
+        mockSuccessfulConnection();
+
+        PowerMockito.mockStatic(HttpUtils.class);
+        PowerMockito.when(HttpUtils.openConnection(any(URL.class)))
+                .thenReturn(mockConnection);
+        PowerMockito.doCallRealMethod()
+                .when(HttpUtils.class);
+        HttpUtils.addHeaders(eq(mockConnection), anyMapOf(String.class, String.class));
+    }
+
+    @Test
+    public void doRequest_givenOperationWithCustomHeaders_shouldSetCustomHeaders() throws IOException {
+        APIUtils.doRequest(getOperationWithCustomHeaders());
+
+        verifyCustomHeadersSet();
+    }
+
+    @Test
+    public void doRequestWithParameters_givenOperationWithCustomHeaders_shouldSetCustomHeaders() throws IOException {
+        APIUtils.doRequestWithParameters(getOperationWithCustomHeaders());
+
+        verifyCustomHeadersSet();
+    }
+
+    @Test
+    public void doDownload_givenOperationWithCustomHeaders_shouldSetCustomHeaders() throws IOException {
+        APIUtils.doDownload(getOperationWithCustomHeaders());
+
+        verifyCustomHeadersSet();
+    }
+
+    private void mockSuccessfulConnection() throws IOException {
+        mockConnection = mock(HttpsURLConnection.class);
+        when(mockConnection.getResponseCode()).thenReturn(OK);
+        when(mockConnection.getOutputStream()).thenReturn(new ByteArrayOutputStream());
+        ObjectMapper mapper = new ObjectMapper();
+        byte[] connectionResponse = mapper.writeValueAsString(getOperationResponse())
+                .getBytes();
+        when(mockConnection.getInputStream()).thenReturn(new ByteArrayInputStream(connectionResponse));
+    }
+
+    private void verifyCustomHeadersSet() {
+        for (Map.Entry<String, String> header : TEST_CONFIG.getCustomHeaders().entrySet()) {
+            verify(mockConnection).setRequestProperty(header.getKey(), header.getValue());
+        }
+    }
+
+    private GCOperation getOperationWithCustomHeaders() {
+        return new Content(TEST_CONFIG);
+    }
+
+    private GCResponse getOperationResponse() {
+        ContentResponse response = new ContentResponse();
+        response.setStatus(OK);
+        ContentResponseData data = new ContentResponseData();
+        data.setResponseData(new ArrayList<GCFile>());
+        response.setResponseData(data);
+        return response;
+    }
+
+    private static GCConfig getTestConfig() {
+        return GCConfig.builder()
+                .apiUrl("https://test.api.url/v0")
+                .connectorKey("test-connector")
+                .password("pass1234")
+                .userAgent("test-agent")
+                .userName("test-user")
+                .customHeaders(getTestHeaders())
+                .build();
+    }
+
+    private static Map<String, String> getTestHeaders() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Authorization", "Basic abcd1234");
+        headers.put("Accept", "application/json");
+        headers.put("Custom-Value", "testing");
+        return headers;
+    }
+
+}

--- a/src/test/java/org/gs4tr/gcc/restclient/util/HttpUtilsTest.java
+++ b/src/test/java/org/gs4tr/gcc/restclient/util/HttpUtilsTest.java
@@ -1,0 +1,55 @@
+package org.gs4tr.gcc.restclient.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@PrepareForTest({ URL.class, HttpUtils.class })
+@RunWith(PowerMockRunner.class)
+public class HttpUtilsTest {
+
+    private static final Map<String, String> TEST_HEADERS = getTestHeaders();
+
+    @Test
+    public void openConnection_givenURL_shouldReturnOpenConnection() throws IOException {
+        URL mockUrl = PowerMockito.mock(URL.class); // URL is a final class, requires PowerMock
+        HttpURLConnection expected = mock(HttpURLConnection.class);
+        PowerMockito.when(mockUrl.openConnection())
+                .thenReturn(expected);
+
+        HttpURLConnection connection = HttpUtils.openConnection(mockUrl);
+
+        assertEquals("Unknown connection returned by 'openConnection'", expected, connection);
+    }
+
+    @Test
+    public void addHeaders_givenMapOfHeaders_shouldSetConnectionHeaders() {
+        HttpURLConnection mockHttpConnection = mock(HttpURLConnection.class);
+        
+        HttpUtils.addHeaders(mockHttpConnection, TEST_HEADERS);
+
+        for (Map.Entry<String, String> header : TEST_HEADERS.entrySet()) {
+            verify(mockHttpConnection).setRequestProperty(header.getKey(), header.getValue());
+        }
+    }
+
+    private static Map<String, String> getTestHeaders() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Authorization", "Basic abcd1234");
+        headers.put("Accept", "application/json");
+        return headers;
+    }
+
+}

--- a/src/test/java/org/gs4tr/gcc/restclient/util/HttpUtilsTest.java
+++ b/src/test/java/org/gs4tr/gcc/restclient/util/HttpUtilsTest.java
@@ -26,7 +26,8 @@ public class HttpUtilsTest {
     public void openConnection_givenURL_shouldReturnOpenConnection() throws IOException {
         URL mockUrl = PowerMockito.mock(URL.class); // URL is a final class, requires PowerMock
         HttpURLConnection expected = mock(HttpURLConnection.class);
-        PowerMockito.when(mockUrl.openConnection())
+        PowerMockito
+                .when(mockUrl.openConnection())
                 .thenReturn(expected);
 
         HttpURLConnection connection = HttpUtils.openConnection(mockUrl);


### PR DESCRIPTION
For any unkown reason the ´init´  was calling the ´getConnectors´ method. This caused some problems and we didn´t see any advantage on do it.

- Removes the ´getConnectors´ call from the initialization.
- Fixes space and indentation format.